### PR TITLE
Exclude style issue that features doesn't respect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN composer global exec 'which phpcs'
 RUN composer global exec 'phpcs -i'
 
 # Set the entrypoint to use the Drupal standard.
-ENTRYPOINT ["phpcs", "-p", "--standard=Drupal"]
+ENTRYPOINT ["phpcs", "-p", "--standard=Drupal --exclude=Drupal.WhiteSpace.OpenTagNewline"]


### PR DESCRIPTION
The "The PHP open tag must be followed by exactly one blank line" BlankLine code sniff isn't respected by features (unless patched - see https://www.drupal.org/node/2782403) so isn't worth checking. I *think* this would do the trick.

I've based this on what I've read at https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#limiting-results-to-specific-sniffs - I presume we can always revert if this isn't correct? I haven't tried it locally, but I'm guessing there's a fair bit of overhead in getting set up locally, so we may as well just merge it in to try it?